### PR TITLE
Adding support for self-hosted resilliency with DNS

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,16 +1,21 @@
+#Sample Hosts File with variables
 
 [bootstrap]
-10.7.183.59
+192.168.0.1
 
 [master]
-10.7.183.6[0:1]
+192.168.0.[2:3]
 
 [workers]
-10.7.183.62
+192.168.0.4
 
 
 [bootstrap:vars]
 node_master=true
+boot_kube_version="v0.3.9"
+#API Server FQDN is for production deployments only. Can be used with an IP or hostname of a master server instead
+api_server_fqdn="kubeapi.test.local"
 
 [master:vars]
 node_master=true
+cni_version="v0.4.0"

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -18,4 +18,4 @@ api_server_fqdn="kubeapi.test.local"
 
 [master:vars]
 node_master=true
-cni_version="v0.4.0"
+cni_version="v0.5.0"

--- a/ansible/roles/bootstrap/defaults/main.yml
+++ b/ansible/roles/bootstrap/defaults/main.yml
@@ -1,0 +1,5 @@
+#Default Override-able variables for bootstrap role
+boot_kube_version: "v0.3.9"
+
+#For DNS Resilliency, override this with FQDN in your environment which resolves to all "master" servers
+api_server_fqdn: "kubeapi.test.local"

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -1,19 +1,25 @@
+#Deploys Bootstrap Node
+
 - name: Ensures bootkube dir exists
-  file: path=/tmp/bootkube state=directory
+  file:
+    path: /tmp/bootkube
+    state: directory
 
 - name: Extract bootkube binaries
   unarchive:
-    src: https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.9/bootkube.tar.gz
+    src: "https://github.com/kubernetes-incubator/bootkube/releases/download/{{ boot_kube_version }}/bootkube.tar.gz"
     dest: /tmp/bootkube
     remote_src: True
 
 - name: Render bootkube manifests
-  command: /tmp/bootkube/bin/linux/bootkube render --asset-dir=/tmp/bootkube/assets --experimental-self-hosted-etcd --etcd-servers=http://10.3.0.15:2379 --api-servers=https://{{ inventory_hostname }}:443
+  command: "/tmp/bootkube/bin/linux/bootkube render --asset-dir=/tmp/bootkube/assets --experimental-self-hosted-etcd --etcd-servers=http://10.3.0.15:2379 --api-servers=https://{{ api_server_fqdn }}:443"
   args:
     creates: /etc/kubernetes/kubeconfig
 
 - name: Ensures /etc/kubernetes dir exists
-  file: path=/etc/kubernetes state=directory
+  file:
+    path: /etc/kubernetes
+    state: directory
 
 - name: copy kubeconfig credentials
   command: cp /tmp/bootkube/assets/auth/kubeconfig /etc/kubernetes/kubeconfig
@@ -32,13 +38,12 @@
     flat: yes
 
 - name: Setup bootkube.service
-  template: 
+  template:
     src: bootkube.service
     dest: /etc/systemd/system/bootkube.service
 
 - name: Run bootkube
-  systemd: 
+  systemd:
     name: bootkube
     state: started
     daemon_reload: yes
-    

--- a/ansible/roles/kubelet/defaults/main.yml
+++ b/ansible/roles/kubelet/defaults/main.yml
@@ -1,2 +1,2 @@
 #Default Override-able variables for the Kubelet role
-cni_version: "v0.4.0"
+cni_version: "v0.5.0"

--- a/ansible/roles/kubelet/defaults/main.yml
+++ b/ansible/roles/kubelet/defaults/main.yml
@@ -1,0 +1,2 @@
+#Default Override-able variables for the Kubelet role
+cni_version: "v0.4.0"

--- a/ansible/roles/kubelet/tasks/main.yml
+++ b/ansible/roles/kubelet/tasks/main.yml
@@ -1,12 +1,17 @@
+#Deploys Kubelet
+
 - name: Ensures CNI dir exists
-  file: path=/opt/cni/bin state=directory
+  file:
+    path: /opt/cni/bin
+    state: directory
 
 - name: Install CNI binaries
   unarchive:
-    src: https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-amd64-v0.4.0.tbz2
+    src: "https://github.com/containernetworking/cni/releases/download/{{ cni_version }}/cni-amd64-{{ cni_version }}.tbz2"
     dest: /opt/cni/bin
     remote_src: True
 
+#TODO: Version kubelet, with checksum
 - name: Install kubelet
   get_url:
     url: http://storage.googleapis.com/kubernetes-release/release/v1.5.3/bin/linux/amd64/kubelet
@@ -15,23 +20,25 @@
     mode: 0755
 
 - name: Ensures /etc/kubernetes dir exists
-  file: path=/etc/kubernetes state=directory
+  file:
+    path: /etc/kubernetes
+    state: directory
 
+#Gets Kubeconfig from the bootstrap node. See roles/bootstrap/tasks/main.yml
 - name: Install kubeconfig
   template:
     src: kubeconfig
     dest: /etc/kubernetes/kubeconfig
 
 - name: Setup kubelet.service
-  template: 
+  template:
     src: kubelet.service
     dest: /etc/systemd/system/kubelet.service
   notify: restart kubelet
 
 - name: Enable Kubelet to be started on boot
-  systemd: 
+  systemd:
     name: kubelet
     state: started
     enabled: yes
     daemon_reload: yes
-


### PR DESCRIPTION
Adding support for DNS resiliency, by adding parameters so users can leverage a FQDN instead of a hardcoded IP or hostname.  Also adding syntax cleanups, version support bootkube/cni, improved readability, and a few small fixes. 